### PR TITLE
Add Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'mechanize'
+gem 'activerecord', '~> 3.2.13'
+gem 'sqlite3', '1.3.5'
+gem 'flickraw'
+


### PR DESCRIPTION
This should be sufficient to get lulz running with `bundle install` on Ruby 1.9.3p551. The appropriate versions of the remaining required gems listed in `INSTALL` are installed automatically as prerequisites.

Tested on Debian 8.2.0, although not thoroughly.
